### PR TITLE
added esp8266 Arduino compatibility 

### DIFF
--- a/Pixels.h
+++ b/Pixels.h
@@ -78,6 +78,20 @@
     #define regtype volatile uint32_t
     #define regsize uint32_t
 
+#elif defined(ESP8266)
+    #include "Arduino.h"
+    #include <pgmspace.h>
+    #define cbi(reg, bitmask) GPOC = bitmask
+    #define sbi(reg, bitmask) GPOS = bitmask
+    #define pulse_high(reg, bitmask) sbi(reg, bitmask); cbi(reg, bitmask);
+    #define pulse_low(reg, bitmask) cbi(reg, bitmask); sbi(reg, bitmask);
+
+    #define cport(port, data) port &= data
+    #define sport(port, data) port |= data
+
+    #define regtype volatile uint32_t
+    #define regsize uint32_t
+
 #else
     #define PROGMEM
 
@@ -117,7 +131,11 @@
 
 
 #define ipart(X) ((int16_t)(X))
-#define round(X) ((uint16_t)(((double)(X))+0.5))
+
+#ifndef ESP8266
+    #define round(X) ((uint16_t)(((double)(X))+0.5))
+#endif
+ 
 #define fpart(X) (((double)(X))-(double)ipart(X))
 #define rfpart(X) (1.0-fpart(X))
 

--- a/Pixels.h
+++ b/Pixels.h
@@ -78,6 +78,20 @@
     #define regtype volatile uint32_t
     #define regsize uint32_t
 
+#elif defined(ESP8266)
+    #include "Arduino.h"
+    #include <pgmspace.h>
+    #define cbi(reg, bitmask) GPOC = bitmask
+    #define sbi(reg, bitmask) GPOS = bitmask
+    #define pulse_high(reg, bitmask) sbi(reg, bitmask); cbi(reg, bitmask);
+    #define pulse_low(reg, bitmask) cbi(reg, bitmask); sbi(reg, bitmask);
+
+    #define cport(port, data) port &= data
+    #define sport(port, data) port |= data
+
+    #define regtype volatile uint32_t
+    #define regsize uint32_t
+
 #else
     #define PROGMEM
 

--- a/Pixels_ILI9341.h
+++ b/Pixels_ILI9341.h
@@ -44,7 +44,7 @@ class Pixels : public PixelsBase
 protected:
     void deviceWriteData(uint8_t high, uint8_t low) {
 
-        #if defined(ESP8266)
+        #if defined(ESP8266) && defined(PIXELS_SPIHW_H)
             int16_t data = (high<<8) | low; //convert back to 16bit
             writeData16(data);
         #else    
@@ -195,7 +195,7 @@ void Pixels::scrollCmd() {
     chipSelect();
     writeCmd(0x37);
 
-    #if defined(ESP8266)
+    #if defined(ESP8266) && defined(PIXELS_SPIHW_H)
         writeData16(currentScroll);
     #else
         writeData(highByte(currentScroll));
@@ -216,7 +216,7 @@ void Pixels::quickFill (int color, int16_t x1, int16_t y1, int16_t x2, int16_t y
 
     registerSelect();
 
-    #if defined(ESP8266)
+    #if defined(ESP8266) && defined(PIXELS_SPIHW_H)
 
          uint8_t colorBin[] = { (uint8_t) (color >> 8), (uint8_t) color };
          writeDataPattern(&colorBin[0], 2, counter);
@@ -292,7 +292,7 @@ void Pixels::setRegion(int16_t x1, int16_t y1, int16_t x2, int16_t y2) {
         }
     }
 
-    #if defined(ESP8266)
+    #if defined(ESP8266) && defined(PIXELS_SPIHW_H)
 
         uint8_t buffC[] = { (uint8_t) (x1 >> 8), (uint8_t) x1, (uint8_t) (x2 >> 8), (uint8_t) x2 };
         uint8_t buffP[] = { (uint8_t) (y1 >> 8), (uint8_t) y1, (uint8_t) (y2 >> 8), (uint8_t) y2 };

--- a/Pixels_SPIsw.h
+++ b/Pixels_SPIsw.h
@@ -131,20 +131,20 @@ void SPIsw::busWrite(uint8_t data) {
     uint8_t c = 8;
     do {
         if (data & 0x80) {
-            *registerSDA |= bitmaskSDA;
+            sbi(registerSDA,bitmaskSDA);
         } else {
-           *registerSDA &= ~bitmaskSDA;
+           cbi(registerSDA,bitmaskSDA);
         }
         data = data<<1;
-        *registerSCL &= ~bitmaskSCL;
+        cbi(registerSCL,bitmaskSCL);
         asm ("nop");
-        *registerSCL |= bitmaskSCL;
+        sbi(registerSCL,bitmaskSCL);
     } while (--c > 0);
 }
 
 void SPIsw::writeCmd(uint8_t cmd) {
     if ( eightBit ) {
-        *registerWR &= ~bitmaskWR;
+        cbi(registerWR,bitmaskWR);
     } else {
         cbi(registerSDA, bitmaskSDA);
         cbi(registerSCL, bitmaskSCL);   // Pull SPI SCK high
@@ -155,7 +155,7 @@ void SPIsw::writeCmd(uint8_t cmd) {
 
 void SPIsw::writeData(uint8_t data) {
     if ( eightBit ) {
-        *registerWR |= bitmaskWR;
+        sbi(registerWR,bitmaskWR);
     } else {
         sbi(registerSDA, bitmaskSDA);
         cbi(registerSCL, bitmaskSCL);   // Pull SPI SCK high

--- a/examples/PixelsTest/PixelsTest.ino
+++ b/examples/PixelsTest/PixelsTest.ino
@@ -1,21 +1,28 @@
-#include <Pixels_PPI16.h>
-#include <Pixels_Antialiasing.h>  // optional (a removal does not impact fonts antialiasing)
-#include <Pixels_HX8352.h>
+//#include <Pixels_PPI16.h>
+//#include <Pixels_Antialiasing.h>  // optional (a removal does not impact fonts antialiasing)
+//#include <Pixels_HX8352.h>
 
-Pixels pxs(240, 400);
+//Pixels pxs(240, 400);
 
-//#include <Pixels_Antialiasing.h>
-//#include <Pixels_SPIsw.h>
-//#include <Pixels_ILI9341.h>
+#include <Pixels_Antialiasing.h>
+#include <Pixels_SPIsw.h>
+#include <Pixels_ILI9341.h>
 
-//Pixels pxs(240, 320);
+Pixels pxs(240, 320);
 
 extern prog_uchar Eurostile13a[494] PROGMEM;
 extern prog_uchar Verdana8[637] PROGMEM;
 
+#define TFT_CLK D5
+#define TFT_MOSI D7
+#define TFT_DC D4
+#define TFT_CS D1
+#define TFT_RST D2
+
 
 	void setup() {
 		pxs.init();
+    pxs.setSpiPins(TFT_CLK,TFT_MOSI,TFT_CS,TFT_RST,TFT_DC);
 		int delayCounter = 0;
 		long start = millis();
 		int orientation = pxs.getOrientation();


### PR DESCRIPTION
Hi,

Your pixels library looks great so I decided to make it compatible with the esp8266 Arduino core. So I could use it in my projects. 

here is the core library if you are not familiar:
https://github.com/esp8266/Arduino

I only have an ILI9341 screen so I only changed that device file, however the changes should work if applied to the other screens. The changes work for both the sw SPI and the hw SPI. 

hwSPI can run through the whole PixelsTest sketch however it does hang on the antialias drawLines grid for some reason. (SPI too slow?) If I comment that out it can make it through the rest of the sketch. 

swSPI draws much faster and doesn't hang on the antialias drawLines gride. So surprisingly swSPI is better on the esp8266 then the hwSPI. Perhaps the esp8266 hwSPI core library needs more work?

If you like these changes you should submit your library to the esp8266 libraries wiki. 
